### PR TITLE
Fix editProfil action

### DIFF
--- a/Profile.php
+++ b/Profile.php
@@ -10,7 +10,7 @@ class Profile
 {
     public $profile;
 
-      public static function editProfil($pseudo, $email, $website, $description)
+    public static function editProfil($pseudo, $email, $website, $description, $idMember)
     {
         // SELECT
 
@@ -23,7 +23,10 @@ class Profile
 
         if (isset($_SESSION ['idMember'])){
 
-            mysqli_query($bdd, "UPDATE member SET pseudo = '$pseudo', email ='$email', website ='$website', description='$description' WHERE idMember = '$idMember'");
+            mysqli_query(
+                $bdd,
+                "UPDATE member SET pseudo = '$pseudo', email ='$email', website ='$website', description='$description' WHERE idMember = '$idMember'"
+            );
 
             header("Location: /");
         }

--- a/controllers/ProfileController.php
+++ b/controllers/ProfileController.php
@@ -27,10 +27,17 @@ class ProfileController extends ActionController
         // member save
         // update save
 
-        Profile::editProfil($_POST['pseudo'], $_POST['email'], $_POST['website'], $_POST['description']);
+        $idMember = $_SESSION['idMember'];
+        Profile::editProfil(
+            $_POST['pseudo'],
+            $_POST['email'],
+            $_POST['website'],
+            $_POST['description'],
+            $idMember
+        );
 
-        
-    
+        $_SESSION['flash_message'] = 'Your profil has been edited';
+        header("Location: /members/");
     }
     
     /**

--- a/model/Profile.php
+++ b/model/Profile.php
@@ -10,7 +10,7 @@ class Profile
 {
     public $profile;
 
-      public static function editProfil($pseudo, $email, $website, $description)
+    public static function editProfil($pseudo, $email, $website, $description, $idMember)
     {
         // SELECT
 
@@ -22,8 +22,10 @@ class Profile
         global $bdd;
 
         if (isset($_SESSION ['idMember'])){
-
-                mysqli_query($bdd, "UPDATE member SET pseudo = '$pseudo', email ='$email', website ='$website', description='$description' WHERE idMember = '$idMember'");
+                mysqli_query(
+                    $bdd,
+                    "UPDATE member SET pseudo = '$pseudo', email ='$email', website ='$website', description='$description' WHERE idMember = '$idMember'"
+                );
         }
         
 

--- a/views/members/index.phtml
+++ b/views/members/index.phtml
@@ -1,4 +1,8 @@
 
+<?php if (isset($_SESSION['flash_message'])) { ?>
+<p class="message"><?php echo $_SESSION['flash_message']; unset($_SESSION['flash_message']); ?></p>
+<?php } ?>
+
 <div class="user">
 	<table>
 		<tr>


### PR DESCRIPTION
## Summary
- reference logged-in member in editProfil action
- send user back to members page with a confirmation message
- update Profile model to accept idMember
- surface flash message on member page

## Testing
- `php -l controllers/ProfileController.php`
- `php -l model/Profile.php`
- `php -l Profile.php`
- `php -l views/members/index.phtml`


------
https://chatgpt.com/codex/tasks/task_e_688b56118544832e942989fcd1fc29c2